### PR TITLE
Add task tagging and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # ClickUp Clone Skeleton
 
-This repository contains a minimal skeleton for a ClickUp-like application. The backend now exposes simple task CRUD endpoints (create, update, delete) with optional due dates and the frontend includes a minimal task list and calendar view.
+This repository contains a minimal skeleton for a ClickUp-like application. The backend now exposes simple task CRUD endpoints (create, update, delete) with optional due dates and the frontend includes a minimal task list and calendar view. Task dependencies can be managed via dedicated API routes.
 
 ## Backend
 - FastAPI app located in `backend/app` with placeholder authentication and task endpoints.
 - Install dependencies using `pip install -r backend/requirements.txt`.
 - Tasks include a `due_date` field so they can appear in the calendar.
+- New `/tasks/{task_id}/dependencies` routes allow adding or removing task dependencies.
+- Tasks now support a `priority` value (`low`, `medium`, `high`, `urgent`).
+- Optional `tag` query parameter filters tasks by tag. Tasks can have a `tags` list.
 
 ## Frontend
 - React application under `frontend/src` demonstrating login, protected routes, list and calendar views.

--- a/backend/app/api/api_v1/endpoints/tasks.py
+++ b/backend/app/api/api_v1/endpoints/tasks.py
@@ -1,20 +1,42 @@
 from fastapi import APIRouter, Depends, HTTPException
-from typing import List
+from typing import List, Dict, Optional
 from datetime import date
 
-from app.schemas.task import Task, TaskBase
+from app.schemas.task import Task, TaskBase, TaskWithDependencies, TaskLink
 from app.api import deps
 
 router = APIRouter()
 
 FAKE_TASKS = [
-    Task(id=1, title="First Task", description="Test", status="open", due_date=date.today()),
-    Task(id=2, title="Second Task", description="Another", status="done", due_date=None),
+    Task(
+        id=1,
+        title="First Task",
+        description="Test",
+        status="open",
+        priority="medium",
+        tags=["backend", "urgent"],
+        due_date=date.today(),
+    ),
+    Task(
+        id=2,
+        title="Second Task",
+        description="Another",
+        status="done",
+        priority="high",
+        tags=["frontend"],
+        due_date=None,
+    ),
 ]
 _next_id = 3
+FAKE_DEPENDENCIES: Dict[int, Dict[str, List[TaskLink]]] = {}
 
 @router.get("/", response_model=List[Task])
-def get_tasks(current_user=Depends(deps.get_current_active_user)):
+def get_tasks(
+    tag: Optional[str] = None,
+    current_user=Depends(deps.get_current_active_user),
+):
+    if tag:
+        return [t for t in FAKE_TASKS if tag in t.tags]
     return FAKE_TASKS
 
 
@@ -47,3 +69,83 @@ def delete_task(task_id: int, current_user=Depends(deps.get_current_active_user)
         if t.id == task_id:
             return FAKE_TASKS.pop(idx)
     raise HTTPException(status_code=404, detail="Task not found")
+
+
+def _get_task(task_id: int) -> Task | None:
+    for t in FAKE_TASKS:
+        if t.id == task_id:
+            return t
+    return None
+
+
+def _get_task_with_deps(task_id: int) -> TaskWithDependencies | None:
+    task = _get_task(task_id)
+    if not task:
+        return None
+    deps = FAKE_DEPENDENCIES.get(task_id, {"successors": [], "predecessors": []})
+    return TaskWithDependencies(
+        id=task.id,
+        title=task.title,
+        description=task.description,
+        status=task.status,
+        priority=task.priority,
+        tags=task.tags,
+        due_date=task.due_date,
+        successors=deps.get("successors", []),
+        predecessors=deps.get("predecessors", []),
+    )
+
+
+@router.get("/{task_id}/dependencies", response_model=TaskWithDependencies)
+def get_dependencies(task_id: int, current_user=Depends(deps.get_current_active_user)):
+    result = _get_task_with_deps(task_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return result
+
+
+@router.post("/{task_id}/dependencies/{depends_on_id}", response_model=TaskWithDependencies)
+def add_dependency(
+    task_id: int,
+    depends_on_id: int,
+    current_user=Depends(deps.get_current_active_user),
+):
+    if task_id == depends_on_id:
+        raise HTTPException(status_code=400, detail="Task cannot depend on itself")
+    task = _get_task(task_id)
+    depends_on = _get_task(depends_on_id)
+    if not task or not depends_on:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    deps = FAKE_DEPENDENCIES.setdefault(task_id, {"successors": [], "predecessors": []})
+    link = TaskLink(id=depends_on.id, title=depends_on.title)
+    if link not in deps["predecessors"]:
+        deps["predecessors"].append(link)
+
+    reverse = FAKE_DEPENDENCIES.setdefault(depends_on_id, {"successors": [], "predecessors": []})
+    back_link = TaskLink(id=task.id, title=task.title)
+    if back_link not in reverse["successors"]:
+        reverse["successors"].append(back_link)
+
+    return _get_task_with_deps(task_id)
+
+
+@router.delete("/{task_id}/dependencies/{depends_on_id}", response_model=TaskWithDependencies)
+def remove_dependency(
+    task_id: int,
+    depends_on_id: int,
+    current_user=Depends(deps.get_current_active_user),
+):
+    task = _get_task(task_id)
+    depends_on = _get_task(depends_on_id)
+    if not task or not depends_on:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    deps = FAKE_DEPENDENCIES.get(task_id)
+    if deps:
+        deps["predecessors"] = [d for d in deps["predecessors"] if d.id != depends_on_id]
+    reverse = FAKE_DEPENDENCIES.get(depends_on_id)
+    if reverse:
+        reverse["successors"] = [d for d in reverse["successors"] if d.id != task_id]
+
+    return _get_task_with_deps(task_id)

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -1,11 +1,21 @@
 from pydantic import BaseModel
 from typing import List
 from datetime import date
+from enum import Enum
+
+
+class TaskPriority(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    URGENT = "urgent"
 
 class TaskBase(BaseModel):
     title: str
     description: str | None = None
     status: str
+    priority: TaskPriority = TaskPriority.MEDIUM
+    tags: List[str] = []
     due_date: date | None = None
 
 class Task(TaskBase):


### PR DESCRIPTION
## Summary
- add `tags` field to task models
- allow optional `tag` query on `/tasks` API
- include tags in dependency responses
- document tag support

## Testing
- `pytest`
- `npm run lint` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870d310d11083289ecb4982aebd79fe