### PR TITLE
Fix tailwind postcss plugin

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,9 @@
+import tailwindcss from '@tailwindcss/postcss'
+import autoprefixer from 'autoprefixer'
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [
+    tailwindcss(),
+    autoprefixer(),
+  ],
 }


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` package in PostCSS config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68718eadd7ac832894d8c2f7aff9b26d