### PR TITLE
Fix default DB connection

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -29,7 +29,9 @@ target_metadata = Base.metadata
 # ... etc.
 
 def get_url():
-    return os.getenv("DATABASE_URL", "postgresql://user:password@localhost/clickup_clone")
+    return os.getenv(
+        "DATABASE_URL", "postgresql://postgres:password@localhost/clickup_clone"
+    )
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,7 +18,10 @@ from app.models.models import Base, User, Workspace, Project, TaskList, Task, Co
 from app.schemas.schemas import *
 
 # Database setup
-SQLALCHEMY_DATABASE_URL = "postgresql://user:password@localhost/clickup_clone"
+SQLALCHEMY_DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://postgres:password@localhost/clickup_clone",
+)
 # For development, you can use SQLite:
 # SQLALCHEMY_DATABASE_URL = "sqlite:///./clickup_clone.db"
 


### PR DESCRIPTION
## Summary
- use `DATABASE_URL` env var for FastAPI DB connection
- update Alembic config to match

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687191fc7b388328b3fcf67621bb1000