### PR TITLE
Fix passlib bcrypt startup error

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository contains a minimal skeleton for a ClickUp-like application. The 
 ## Backend
 - FastAPI app located in `backend/app` with placeholder authentication and task endpoints.
 - Install dependencies using `pip install -r backend/requirements.txt`.
+- The `requirements.txt` pins `bcrypt==3.2.2` to avoid a startup error caused
+  by newer versions removing `__about__.__version__`.
 - Tasks include a `due_date` field so they can appear in the calendar.
 - New `/tasks/{task_id}/dependencies` routes allow adding or removing task dependencies.
 - Tasks now support a `priority` value (`low`, `medium`, `high`, `urgent`).

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,5 +5,6 @@ psycopg2-binary==2.9.9
 pydantic[email]==2.5.3
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
+bcrypt==3.2.2
 python-multipart==0.0.6
 python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- pin `bcrypt==3.2.2` to work around passlib `__about__` issue
- document `bcrypt` pin in README

## Testing
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68719699a8a483288b9471c8b5e0d18a