### PR TITLE
Add user profile feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ This repository contains a minimal skeleton for a ClickUp-like application. The 
 - Tasks now support a `priority` value (`low`, `medium`, `high`, `urgent`).
 - Optional `tag` query parameter filters tasks by tag. Tasks can have a `tags` list.
 - Tasks can now be archived and restored. Archived tasks are hidden from default queries.
+- `/users/me` endpoint allows fetching and updating the authenticated user's profile.
 
 ## Frontend
 - React application under `frontend/src` demonstrating login, protected routes, list and calendar views.
 - Tasks on the board include an archive button that hides them without deletion.
+- New profile page lets users edit their full name and avatar.
 
 This code is a lightweight starting point that can be expanded with full database models and advanced features.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -204,6 +204,23 @@ def read_users_me(current_user: User = Depends(get_current_user)):
     return current_user
 
 # User endpoints
+@app.get("/users/me", response_model=schemas.User)
+def read_user_me(current_user: User = Depends(get_current_user)):
+    return current_user
+
+@app.put("/users/me", response_model=schemas.User)
+def update_user_me(
+    user_update: schemas.UserUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    update_data = user_update.dict(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(current_user, key, value)
+    db.commit()
+    db.refresh(current_user)
+    return current_user
+
 @app.get("/users/", response_model=List[schemas.User])
 def read_users(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
     users = db.query(User).offset(skip).limit(limit).all()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import Dashboard from './pages/Dashboard';
 import ProjectView from './pages/ProjectView';
+import ProfilePage from './pages/ProfilePage';
 import Layout from './components/Layout';
 
 // Placeholder components for missing routes
@@ -57,6 +58,7 @@ function App() {
                 <Route path="calendar" element={<CalendarPage />} />
                 <Route path="time-tracking" element={<TimeTrackingPage />} />
                 <Route path="reports" element={<ReportsPage />} />
+                <Route path="profile" element={<ProfilePage />} />
                 <Route path="project/:projectId" element={<ProjectView />} />
                 <Route index element={<Navigate to="/dashboard" replace />} />
               </Route>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -81,7 +81,7 @@ function Header() {
                 <button
                   onClick={() => {
                     setShowUserMenu(false);
-                    // Navigate to profile
+                    navigate('/profile');
                   }}
                   className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                 >

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -59,6 +59,7 @@ export function AuthProvider({ children }) {
 
   const value = {
     user,
+    setUser,
     login,
     register,
     logout,

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,0 +1,96 @@
+import React, { useState, useEffect } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { useNotification } from '../contexts/NotificationContext';
+import apiClient from '../services/api';
+
+function ProfilePage() {
+  const { user, setUser } = useAuth();
+  const { addNotification } = useNotification();
+  const [formData, setFormData] = useState({ full_name: '', avatar_url: '' });
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (user) {
+      setFormData({
+        full_name: user.full_name || '',
+        avatar_url: user.avatar_url || ''
+      });
+    }
+  }, [user]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const response = await apiClient.put('/users/me', formData);
+      setUser(response.data);
+      addNotification('Profile updated', 'success');
+    } catch (error) {
+      addNotification('Failed to update profile', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!user) return null;
+
+  return (
+    <div className="max-w-xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Profile Settings</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+          <input
+            type="email"
+            value={user.email}
+            disabled
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-100"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Username</label>
+          <input
+            type="text"
+            value={user.username}
+            disabled
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-100"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Full Name</label>
+          <input
+            type="text"
+            name="full_name"
+            value={formData.full_name}
+            onChange={handleChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Avatar URL</label>
+          <input
+            type="text"
+            name="avatar_url"
+            value={formData.avatar_url}
+            onChange={handleChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg disabled:opacity-50"
+        >
+          {loading ? 'Saving...' : 'Save Changes'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default ProfilePage;


### PR DESCRIPTION
## Summary
- add `/users/me` API to view and update current user
- expose `setUser` from AuthContext for updating user in UI
- create ProfilePage and route it in App
- link ProfilePage from Header menu
- document profile capability in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871ab8cf95c8328a51942d2abd040c0