### PR TITLE
Add time tracking and custom fields

### DIFF
--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -254,3 +254,65 @@ class SearchResults(BaseModel):
     tasks: List[Task]
     projects: List[Project]
     users: List[User]
+# Custom Field Schemas
+class CustomFieldBase(BaseModel):
+    name: str
+    field_type: str = "text"
+    options: Optional[str] = None
+    workspace_id: Optional[int] = None
+    is_required: bool = False
+
+class CustomFieldCreate(CustomFieldBase):
+    pass
+
+class CustomFieldInDB(CustomFieldBase):
+    id: int
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+class CustomField(CustomFieldInDB):
+    pass
+
+class TaskCustomFieldValue(BaseModel):
+    id: int
+    task_id: int
+    field: CustomField
+    value: Optional[str] = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+# Time Entry Schemas
+class TimeEntryBase(BaseModel):
+    start_time: datetime
+    end_time: datetime
+    duration: float
+
+class TimeEntryCreate(TimeEntryBase):
+    task_id: int
+
+class TimeEntryInDB(TimeEntryBase):
+    id: int
+    task_id: int
+    user_id: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+class TimeEntry(TimeEntryInDB):
+    pass
+
+# Attachment Schemas
+class AttachmentBase(BaseModel):
+    filename: str
+    file_path: str
+
+class Attachment(AttachmentBase):
+    id: int
+    task_id: int
+    uploaded_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import RegisterPage from './pages/RegisterPage';
 import Dashboard from './pages/Dashboard';
 import ProjectView from './pages/ProjectView';
 import Layout from './components/Layout';
+import TimeTracking from './pages/TimeTracking';
 
 // Placeholder components for missing routes
 const InboxPage = () => (
@@ -25,12 +26,6 @@ const CalendarPage = () => (
   </div>
 );
 
-const TimeTrackingPage = () => (
-  <div className="p-8 text-center">
-    <h1 className="text-2xl font-bold text-gray-900 mb-4">Time Tracking</h1>
-    <p className="text-gray-600">Time tracking functionality coming soon...</p>
-  </div>
-);
 
 const ReportsPage = () => (
   <div className="p-8 text-center">
@@ -55,7 +50,7 @@ function App() {
                 <Route path="dashboard" element={<Dashboard />} />
                 <Route path="inbox" element={<InboxPage />} />
                 <Route path="calendar" element={<CalendarPage />} />
-                <Route path="time-tracking" element={<TimeTrackingPage />} />
+                <Route path="time-tracking" element={<TimeTracking />} />
                 <Route path="reports" element={<ReportsPage />} />
                 <Route path="project/:projectId" element={<ProjectView />} />
                 <Route index element={<Navigate to="/dashboard" replace />} />
@@ -69,3 +64,4 @@ function App() {
 }
 
 export default App;
+

--- a/frontend/src/pages/TimeTracking.jsx
+++ b/frontend/src/pages/TimeTracking.jsx
@@ -1,0 +1,90 @@
+// pages/TimeTracking.jsx
+import React, { useState, useEffect } from 'react';
+import apiClient from '../services/api';
+import { useAuth } from '../contexts/AuthContext';
+
+function TimeTracking() {
+  const { user } = useAuth();
+  const [tasks, setTasks] = useState([]);
+  const [selectedTask, setSelectedTask] = useState('');
+  const [entries, setEntries] = useState([]);
+  const [formData, setFormData] = useState({
+    start_time: '',
+    end_time: '',
+    duration: 0
+  });
+
+  useEffect(() => {
+    if (!user) return;
+    apiClient.get(`/tasks?assignee_id=${user.id}`)
+      .then(res => setTasks(res.data))
+      .catch(err => console.error(err));
+  }, [user]);
+
+  const loadEntries = (taskId) => {
+    apiClient.get(`/tasks/${taskId}/time-entries`)
+      .then(res => setEntries(res.data))
+      .catch(err => console.error(err));
+  };
+
+  const handleSelectTask = (e) => {
+    const taskId = e.target.value;
+    setSelectedTask(taskId);
+    if (taskId) loadEntries(taskId);
+    else setEntries([]);
+  };
+
+  const handleChange = (e) => {
+    setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!selectedTask) return;
+    try {
+      await apiClient.post(`/tasks/${selectedTask}/time-entries`, {
+        task_id: parseInt(selectedTask),
+        start_time: formData.start_time,
+        end_time: formData.end_time,
+        duration: parseFloat(formData.duration)
+      });
+      setFormData({ start_time: '', end_time: '', duration: 0 });
+      loadEntries(selectedTask);
+    } catch (err) {
+      console.error('Error creating entry', err);
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">Time Tracking</h1>
+      <div className="mb-4">
+        <select value={selectedTask} onChange={handleSelectTask} className="border px-2 py-1">
+          <option value="">Select task</option>
+          {tasks.map(t => (
+            <option key={t.id} value={t.id}>{t.title}</option>
+          ))}
+        </select>
+      </div>
+      {selectedTask && (
+        <div>
+          <form onSubmit={handleSubmit} className="space-x-2 mb-4">
+            <input type="datetime-local" name="start_time" value={formData.start_time} onChange={handleChange} className="border px-2" required />
+            <input type="datetime-local" name="end_time" value={formData.end_time} onChange={handleChange} className="border px-2" required />
+            <input type="number" step="0.1" name="duration" value={formData.duration} onChange={handleChange} className="border px-2 w-24" />
+            <button type="submit" className="px-3 py-1 bg-blue-600 text-white rounded">Add Entry</button>
+          </form>
+          <ul className="space-y-2">
+            {entries.map(entry => (
+              <li key={entry.id} className="border px-3 py-2 rounded">
+                {new Date(entry.start_time).toLocaleString()} - {new Date(entry.end_time).toLocaleString()} ({entry.duration}h)
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TimeTracking;


### PR DESCRIPTION
## Summary
- support file uploads and time tracking in backend
- allow custom fields on tasks
- expose new API routes for time entries, attachments, and custom fields
- add matching React page for time tracking

## Testing
- `python -m py_compile $(git ls-files "backend/**/*.py")`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871b2025f288328813ecc44a76b4d3a