### PR TITLE
Add accessibility and autocomplete improvements

### DIFF
--- a/frontend/src/components/CreateTaskModal.jsx
+++ b/frontend/src/components/CreateTaskModal.jsx
@@ -94,12 +94,14 @@ function CreateTaskModal({ projectId, listId, onClose, onTaskCreated }) {
         <form onSubmit={handleSubmit} className="p-6 space-y-6">
           {/* Title */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="task-title" className="block text-sm font-medium text-gray-700 mb-2">
               Task Title *
             </label>
             <input
+              id="task-title"
               type="text"
               name="title"
+              autoComplete="off"
               value={formData.title}
               onChange={handleChange}
               placeholder="Enter task title..."
@@ -110,11 +112,13 @@ function CreateTaskModal({ projectId, listId, onClose, onTaskCreated }) {
 
           {/* Description */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="task-description" className="block text-sm font-medium text-gray-700 mb-2">
               Description
             </label>
             <textarea
+              id="task-description"
               name="description"
+              autoComplete="off"
               value={formData.description}
               onChange={handleChange}
               placeholder="Describe the task..."
@@ -126,11 +130,13 @@ function CreateTaskModal({ projectId, listId, onClose, onTaskCreated }) {
           {/* Priority and Due Date Row */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label htmlFor="task-priority" className="block text-sm font-medium text-gray-700 mb-2">
                 Priority
               </label>
               <select
+                id="task-priority"
                 name="priority"
+                autoComplete="off"
                 value={formData.priority}
                 onChange={handleChange}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
@@ -143,12 +149,14 @@ function CreateTaskModal({ projectId, listId, onClose, onTaskCreated }) {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label htmlFor="task-due-date" className="block text-sm font-medium text-gray-700 mb-2">
                 Due Date
               </label>
               <input
+                id="task-due-date"
                 type="date"
                 name="due_date"
+                autoComplete="off"
                 value={formData.due_date}
                 onChange={handleChange}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
@@ -158,12 +166,14 @@ function CreateTaskModal({ projectId, listId, onClose, onTaskCreated }) {
 
           {/* Estimated Hours */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="task-est-hours" className="block text-sm font-medium text-gray-700 mb-2">
               Estimated Hours
             </label>
             <input
+              id="task-est-hours"
               type="number"
               name="estimated_hours"
+              autoComplete="off"
               value={formData.estimated_hours}
               onChange={handleChange}
               placeholder="Enter estimated hours..."

--- a/frontend/src/components/CreateWorkspaceModal.jsx
+++ b/frontend/src/components/CreateWorkspaceModal.jsx
@@ -63,12 +63,14 @@ function CreateWorkspaceModal({ onClose, onWorkspaceCreated }) {
         {/* Form */}
         <form onSubmit={handleSubmit} className="p-6 space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="workspace-name" className="block text-sm font-medium text-gray-700 mb-2">
               Workspace Name *
             </label>
             <input
+              id="workspace-name"
               type="text"
               name="name"
+              autoComplete="organization"
               value={formData.name}
               onChange={handleChange}
               placeholder="Enter workspace name..."
@@ -78,11 +80,13 @@ function CreateWorkspaceModal({ onClose, onWorkspaceCreated }) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="workspace-description" className="block text-sm font-medium text-gray-700 mb-2">
               Description
             </label>
             <textarea
+              id="workspace-description"
               name="description"
+              autoComplete="off"
               value={formData.description}
               onChange={handleChange}
               placeholder="Describe your workspace..."

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -32,8 +32,14 @@ function Header() {
             <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
               <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
             </div>
+            <label htmlFor="header-search" className="sr-only">
+              Search
+            </label>
             <input
+              id="header-search"
+              name="search"
               type="text"
+              autoComplete="off"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Search tasks, projects..."

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -142,8 +142,14 @@ function Sidebar() {
           <div className="p-4 border-b border-gray-200">
             <div className="relative">
               <MagnifyingGlassIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <label htmlFor="sidebar-search" className="sr-only">
+                Search
+              </label>
               <input
+                id="sidebar-search"
+                name="sidebar-search"
                 type="text"
+                autoComplete="off"
                 placeholder="Search"
                 className="w-full pl-10 pr-4 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent"
               />

--- a/frontend/src/components/TaskModal.jsx
+++ b/frontend/src/components/TaskModal.jsx
@@ -33,9 +33,21 @@ const TaskModal = ({ task, onClose }) => {
 
   return (
     <div>
-      <input value={title} onChange={e => setTitle(e.target.value)} />
+      <label htmlFor="task-modal-title">Title</label>
       <input
+        id="task-modal-title"
+        name="title"
+        type="text"
+        autoComplete="off"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+      />
+      <label htmlFor="task-modal-due-date">Due Date</label>
+      <input
+        id="task-modal-due-date"
+        name="due_date"
         type="date"
+        autoComplete="off"
         value={dueDate}
         onChange={e => setDueDate(e.target.value)}
       />

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -44,38 +44,48 @@ function ProfilePage() {
       <h1 className="text-2xl font-bold mb-4">Profile Settings</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+          <label htmlFor="profile-email" className="block text-sm font-medium text-gray-700 mb-1">Email</label>
           <input
+            id="profile-email"
+            name="email"
             type="email"
+            autoComplete="email"
             value={user.email}
             disabled
             className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-100"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Username</label>
+          <label htmlFor="profile-username" className="block text-sm font-medium text-gray-700 mb-1">Username</label>
           <input
+            id="profile-username"
+            name="username"
             type="text"
+            autoComplete="username"
             value={user.username}
             disabled
             className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-100"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Full Name</label>
+          <label htmlFor="profile-full-name" className="block text-sm font-medium text-gray-700 mb-1">Full Name</label>
           <input
+            id="profile-full-name"
             type="text"
             name="full_name"
+            autoComplete="name"
             value={formData.full_name}
             onChange={handleChange}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Avatar URL</label>
+          <label htmlFor="profile-avatar-url" className="block text-sm font-medium text-gray-700 mb-1">Avatar URL</label>
           <input
+            id="profile-avatar-url"
             type="text"
             name="avatar_url"
+            autoComplete="url"
             value={formData.avatar_url}
             onChange={handleChange}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg"


### PR DESCRIPTION
## Summary
- wire up `id`, `name` and `htmlFor` for profile fields
- improve workspace modal form markup
- label task creation inputs
- add hidden labels to header and sidebar search boxes
- update simple task modal inputs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871b33fa8a883289b261c62ff6d50a6