### PR TITLE
Fix login

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -98,6 +98,11 @@ export const AuthProvider = ({ children }) => {
       // Call apiService.login with email and password
       const loginData = await apiService.login(email, password);
 
+      // Persist token for subsequent requests
+      if (loginData?.access_token) {
+        localStorage.setItem('accessToken', loginData.access_token);
+      }
+
       // Get current user data
       const user = await apiService.getCurrentUser();
 
@@ -113,7 +118,11 @@ export const AuthProvider = ({ children }) => {
       toast.success(`Welcome back, ${user.full_name}!`);
       return { success: true };
     } catch (error) {
-      const message = error.response?.data?.detail || 'Login failed';
+      let message = error.response?.data?.detail || 'Login failed';
+      const status = error.response?.status;
+      if (status === 402) {
+        message = 'Payment required. Please check your subscription.';
+      }
       dispatch({ type: 'SET_ERROR', payload: message });
       toast.error(message);
       return { success: false, error: message };

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -29,7 +29,7 @@ const LoginPage = () => {
     setIsSubmitting(true);
 
     try {
-      const result = await login(formData);
+      const result = await login(formData.username, formData.password);
       if (result.success) {
         navigate(from, { replace: true });
       }

--- a/test_api.sh
+++ b/test_api.sh
@@ -14,9 +14,16 @@ echo " - API docs response code"
 
 # Test auth endpoint with demo credentials
 echo -e "\n3. Testing login with demo credentials..."
-TOKEN=$(curl -s -X POST "http://localhost:8000/api/v1/auth/token" \
+LOGIN_RES=$(curl -s -w "%{http_code}" -o /tmp/login.json -X POST \
+  "http://localhost:8000/api/v1/auth/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=demo@example.com&password=demo123" | jq -r '.access_token')
+  -d "username=demo@example.com&password=demo123")
+if [ -f /tmp/login.json ]; then
+  TOKEN=$(cat /tmp/login.json | jq -r '.access_token')
+else
+  TOKEN=""
+fi
+echo "Login response code: $LOGIN_RES"
 
 if [ "$TOKEN" != "null" ] && [ ! -z "$TOKEN" ]; then
   echo "✅ Login successful! Token: ${TOKEN:0:20}..."


### PR DESCRIPTION
## Summary
- fix login parameter usage in LoginPage
- persist accessToken after login in AuthContext
- show friendly message for payment-related login failures
- print login HTTP status in test script

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `bash test_api.sh` *(fails: login failed because server isn't running)*

------
https://chatgpt.com/codex/tasks/task_e_687248717904832893f5662fc061207a